### PR TITLE
add Assertions under Command Classes

### DIFF
--- a/src/main/java/geegar/command/AddCommand.java
+++ b/src/main/java/geegar/command/AddCommand.java
@@ -12,12 +12,22 @@ import geegar.task.TaskList;
 public class AddCommand extends Command {
     private Task task;
 
+    /**
+     * Taskes in the tasks and Creates an instance of a AddCommand object
+     * @param task
+     */
     public AddCommand(Task task) {
+        assert task != null : "Task in AddCommand must not be null";
         this.task = task;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList in AddCommand must not be null";
+        assert gui != null : "Gui in AddCommand must not be null";
+        assert storage != null : "Storage in AddCommand must not be null";
+
         tasks.add(task);
         storage.save(tasks.getTasks());
         gui.printTaskAdded(task, tasks.size());

--- a/src/main/java/geegar/command/DeleteCommand.java
+++ b/src/main/java/geegar/command/DeleteCommand.java
@@ -13,13 +13,22 @@ public class DeleteCommand extends Command {
 
     private int taskNumber;
 
+    /**
+     * Creates an instance of a DeleteCommand using the input taskNumber
+     * @param taskNumber
+     */
     public DeleteCommand(int taskNumber) {
-
+        assert taskNumber > 0 : "Task number must be positive";
         this.taskNumber = taskNumber;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList in DeleteCommand must not be null";
+        assert gui != null : "Gui in DeleteCommand must not be null";
+        assert storage != null : "Storage in DeleteCommand must not be null";
+
         Task deletedTask = tasks.delete(taskNumber - 1);
         storage.save(tasks.getTasks());
         gui.printTaskDeleted(deletedTask, tasks.size());

--- a/src/main/java/geegar/command/ExitCommand.java
+++ b/src/main/java/geegar/command/ExitCommand.java
@@ -12,6 +12,7 @@ public class ExitCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+        assert gui != null : "Gui must not be null";
         gui.printGoodbye();
     }
 

--- a/src/main/java/geegar/command/FindCommand.java
+++ b/src/main/java/geegar/command/FindCommand.java
@@ -13,11 +13,17 @@ public class FindCommand extends Command {
     private String keyword;
 
     public FindCommand(String keyword) {
+        assert keyword != null && !keyword.trim().isEmpty() : "Keyword cannot be null or empty";
         this.keyword = keyword;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList must not be null";
+        assert gui != null : "Gui must not be null";
+        assert storage != null : "Storage must not be null";
+
         gui.printFind();
         ArrayList<Task> tasksOnKeyword = tasks.showTasksOnKeyword(keyword);
         for (Task task : tasksOnKeyword) {

--- a/src/main/java/geegar/command/ListCommand.java
+++ b/src/main/java/geegar/command/ListCommand.java
@@ -12,6 +12,11 @@ public class ListCommand extends Command {
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList must not be null";
+        assert gui != null : "Gui must not be null";
+        assert storage != null : "Storage must not be null";
+
         gui.printTaskList(tasks);
     }
 }

--- a/src/main/java/geegar/command/MarkCommand.java
+++ b/src/main/java/geegar/command/MarkCommand.java
@@ -12,11 +12,17 @@ public class MarkCommand extends Command {
     private int taskNumber;
 
     public MarkCommand(int taskNumber) {
+        assert taskNumber > 0 : "Task number must be positive in MarkCommand";
         this.taskNumber = taskNumber;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList must not be null";
+        assert gui != null : "Gui must not be null";
+        assert storage != null : "Storage must not be null";
+
         tasks.markTask(taskNumber - 1);
         storage.save(tasks.getTasks());
         gui.printTaskMarked(tasks.get(taskNumber - 1));

--- a/src/main/java/geegar/command/ScheduleCommand.java
+++ b/src/main/java/geegar/command/ScheduleCommand.java
@@ -16,12 +16,17 @@ public class ScheduleCommand extends Command {
     private LocalDate date;
 
     public ScheduleCommand(LocalDate date) {
-
+        assert date != null : "Date in ScheduleCommand must not be null";
         this.date = date;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList must not be null";
+        assert gui != null : "Gui must not be null";
+        assert storage != null : "Storage must not be null";
+
         gui.printSchedule();
         ArrayList<Task> tasksOnDate = tasks.showTasksOnDate(date);
         for (Task task : tasksOnDate) {

--- a/src/main/java/geegar/command/UnmarkCommand.java
+++ b/src/main/java/geegar/command/UnmarkCommand.java
@@ -12,11 +12,17 @@ public class UnmarkCommand extends Command {
     private int taskNumber;
 
     public UnmarkCommand(int taskNumber) {
+        assert taskNumber > 0 : "Task number must be positive in UnmarkCommand";
         this.taskNumber = taskNumber;
     }
 
     @Override
     public void execute(TaskList tasks, Gui gui, Storage storage) throws GeegarException {
+
+        assert tasks != null : "TaskList must not be null";
+        assert gui != null : "Gui must not be null";
+        assert storage != null : "Storage must not be null";
+
         tasks.unmarkTask(taskNumber - 1);
         storage.save(tasks.getTasks());
         gui.printTaskUnmarked(tasks.get(taskNumber - 1));

--- a/src/main/java/geegar/task/Deadline.java
+++ b/src/main/java/geegar/task/Deadline.java
@@ -38,7 +38,7 @@ public class Deadline extends Task {
 
     @Override
     public String toString() {
-        return "[D]" + super.toString() +
-                " (by: " + this.by.format(Task.DISPLAY_FORMATTER) + ")";
+        return "[D]" + super.toString()
+                + " (by: " + this.by.format(Task.DISPLAY_FORMATTER) + ")";
     }
 }


### PR DESCRIPTION
Currently, the Command classes assume that their inptus are always valid and other utility classes for execution, (TaskList, Gui, Storage) never null. However, this is only implicit in the code.

Without explicit documentation or runtime checks, programmer errors may occur when failing to do proper user checks under the Parser Class, this errors may go unoticed and make it harder to debug in the future.

Add Java `assert` statements in consturctors and execute() methods to check invariants (like non-null parameters, positive task numbers). This enforces these assumptions during development using the -ea command.

Use `assert` instead of if-else beacuse these checks guards against programmer mistakes, not user input errors (which should have been captured via the Parser class before passing into the Command Class.)

This also potentially helps to improve code readability by documenting necessary assumptions direclty in the code to catch bugs earleir. Assertions can also be easily disabled in production without affecting runtime performance.